### PR TITLE
Change release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,12 @@
 name: Run release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version"
-        required: true
-        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - "package.json"
 
 jobs:
   call:
-    uses: chick-p/github-actions-shared-workflow/.github/workflows/release-npm-package.yml@main
-    with:
-      version: ${{ inputs.version }}
+    uses: chick-p/github-actions-shared-workflow/.github/workflows/release-npm-package-auto.yml@main


### PR DESCRIPTION
Avoid `[remote rejected] main -> main (protected branch hook declined)` error.